### PR TITLE
[feat] 회원정보를 가져오는 AOP 구현

### DIFF
--- a/src/main/java/com/partimestudy/assignment/domain/exception/ErrorCode.java
+++ b/src/main/java/com/partimestudy/assignment/domain/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     EXPIRED_TOKEN("만료된 토큰입니다."),
     INVALID_TOKEN("유효하지 않은 토큰입니다."),
 
+    // Auth
+    NOT_LOGIN("로그인 상태가 아닙니다."),
+
     // USER
     ALREADY_EXIST_ID("이미 존재하는 아이디입니다."),
     NOT_FOUND_USER("회원을 찾을 수 없습니다."),

--- a/src/main/java/com/partimestudy/assignment/domain/token/TokenProvider.java
+++ b/src/main/java/com/partimestudy/assignment/domain/token/TokenProvider.java
@@ -1,7 +1,11 @@
 package com.partimestudy.assignment.domain.token;
 
+import java.util.Map;
+
 public interface TokenProvider {
     String createAccessToken(String userToken);
 
     void validateToken(String token);
+
+    Map<String, Object> extractClaims(String token);
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/config/FilterConfig.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/config/FilterConfig.java
@@ -1,0 +1,39 @@
+package com.partimestudy.assignment.infrastructure.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.partimestudy.assignment.infrastructure.jwt.JwtProvider;
+import com.partimestudy.assignment.interfaces.filter.AuthExceptionHandlerFilter;
+import com.partimestudy.assignment.interfaces.filter.JwtFilter;
+import com.partimestudy.assignment.interfaces.support.AuthenticationContext;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+    private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public FilterRegistrationBean<JwtFilter> jwtFilter() {
+        FilterRegistrationBean<JwtFilter> jwtFilter = new FilterRegistrationBean<>();
+        jwtFilter.setFilter(new JwtFilter(jwtProvider, authenticationContext));
+        jwtFilter.addUrlPatterns("/api/*");
+        jwtFilter.setOrder(2);
+        return jwtFilter;
+    }
+
+    @Bean
+    public FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter() {
+        FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter = new FilterRegistrationBean<>();
+        authExceptionHandlerFilter.setFilter(new AuthExceptionHandlerFilter(objectMapper));
+        authExceptionHandlerFilter.addUrlPatterns("/api/*");
+        authExceptionHandlerFilter.setOrder(1);
+        return authExceptionHandlerFilter;
+    }
+}

--- a/src/main/java/com/partimestudy/assignment/infrastructure/config/WebConfig.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.partimestudy.assignment.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.partimestudy.assignment.interfaces.support.AuthArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/com/partimestudy/assignment/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.partimestudy.assignment.infrastructure.jwt;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ import com.partimestudy.assignment.domain.exception.UnAuthorizedException;
 import com.partimestudy.assignment.domain.token.TokenProvider;
 import com.partimestudy.assignment.infrastructure.common.properties.JwtProperties;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -54,5 +56,16 @@ public class JwtProvider implements TokenProvider {
         } catch (JwtException e) {
             throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    @Override
+    public Map<String, Object> extractClaims(String token) {
+        final Claims claims = Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        return Collections.unmodifiableMap(claims);
     }
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/filter/JwtFilter.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/filter/JwtFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.partimestudy.assignment.domain.exception.ErrorCode;
 import com.partimestudy.assignment.domain.exception.UnAuthorizedException;
 import com.partimestudy.assignment.infrastructure.jwt.JwtProvider;
+import com.partimestudy.assignment.interfaces.support.AuthenticationContext;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,6 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final List<String> excludeUrlPatterns = List.of("/api/users/auth/**");
 
     private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -47,6 +49,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = extractJwt(request)
             .orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_AUTH_HEADER));
         jwtProvider.validateToken(token);
+        authenticationContext.setUserToken(jwtProvider.extractClaims(token));
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/partimestudy/assignment/interfaces/support/Auth.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/support/Auth.java
@@ -1,0 +1,11 @@
+package com.partimestudy.assignment.interfaces.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/partimestudy/assignment/interfaces/support/AuthArgumentResolver.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/support/AuthArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.partimestudy.assignment.interfaces.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.partimestudy.assignment.domain.exception.ErrorCode;
+import com.partimestudy.assignment.domain.exception.UnAuthorizedException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class)
+            && parameter.getParameterType().isAssignableFrom(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) {
+        return authenticationContext.getPrincipal()
+            .orElseThrow(() -> new UnAuthorizedException(ErrorCode.NOT_LOGIN));
+    }
+}

--- a/src/main/java/com/partimestudy/assignment/interfaces/support/AuthenticationContext.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/support/AuthenticationContext.java
@@ -1,0 +1,21 @@
+package com.partimestudy.assignment.interfaces.support;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthenticationContext {
+    private String userToken;
+
+    public Optional<String> getPrincipal() {
+        return Optional.ofNullable(userToken);
+    }
+
+    public void setUserToken(Map<String, Object> claims) {
+        this.userToken = claims.get("userToken").toString();
+    }
+}


### PR DESCRIPTION
## Issue
- #12 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 회원 정보를 가져오는 AOP를 구현했습니다.
  - `@Auth` 애노테이션을 생성하고 이를 통해 쉽게 현재 로그인된 사용자의 userToken을 가져올 수 있도록 구현했습니다.
  - ArgumentResolver를 통해 파라미터에 붙은 `@Auth`을 resolve할 수 있도록 했습니다.
  - AuthenticationContext 클래스에 userToken를 담았습니다.
   - 해당 클래스는 `@RequestScope` 애노테이션을 이용해 요청이 생성될 때마다 빈이 생성되어 등록되도록 했습니다.