### PR TITLE
[feat] 내 정보 조회 기능 구현

### DIFF
--- a/http-test/user-api.http
+++ b/http-test/user-api.http
@@ -18,3 +18,11 @@ Content-Type: application/json
   "password": "qwer1234@"
 }
 
+> {%
+    client.global.set("access_token", "bearer " + response.body.accessToken)
+%}
+
+### 내 정보 조회
+GET http://localhost:8080/api/users/details
+Content-Type: application/json
+Authorization: {{access_token}}

--- a/src/main/java/com/partimestudy/assignment/application/user/UserFacade.java
+++ b/src/main/java/com/partimestudy/assignment/application/user/UserFacade.java
@@ -24,4 +24,8 @@ public class UserFacade {
         UserInfo info = userService.login(command);
         return tokenService.createToken(info);
     }
+
+    public UserInfo.Details details(String userToken) {
+        return userService.details(userToken);
+    }
 }

--- a/src/main/java/com/partimestudy/assignment/domain/user/UserInfo.java
+++ b/src/main/java/com/partimestudy/assignment/domain/user/UserInfo.java
@@ -4,9 +4,20 @@ import lombok.Getter;
 
 @Getter
 public class UserInfo {
-    private String userToken;
+    private final String userToken;
 
     public UserInfo(User user) {
         this.userToken = user.getUserToken();
+    }
+
+    public record Details(
+        String loginId,
+        String name,
+        String purpose
+    ) {
+
+        public static UserInfo.Details from(User user) {
+            return new UserInfo.Details(user.getLoginId(), user.getName(), user.getPurpose().getContent());
+        }
     }
 }

--- a/src/main/java/com/partimestudy/assignment/domain/user/UserReader.java
+++ b/src/main/java/com/partimestudy/assignment/domain/user/UserReader.java
@@ -4,4 +4,6 @@ public interface UserReader {
     void checkDuplicationLoginId(String loginId);
 
     User findByLoginId(String loginId);
+
+    User findByUserToken(String userToken);
 }

--- a/src/main/java/com/partimestudy/assignment/domain/user/UserService.java
+++ b/src/main/java/com/partimestudy/assignment/domain/user/UserService.java
@@ -4,4 +4,6 @@ public interface UserService {
     UserInfo signup(UserCommand.Signup command);
 
     UserInfo login(UserCommand.Login command);
+
+    UserInfo.Details details(String userToken);
 }

--- a/src/main/java/com/partimestudy/assignment/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/partimestudy/assignment/domain/user/UserServiceImpl.java
@@ -34,6 +34,12 @@ public class UserServiceImpl implements UserService {
         return new UserInfo(user);
     }
 
+    @Override
+    public UserInfo.Details details(String userToken) {
+        User user = userReader.findByUserToken(userToken);
+        return UserInfo.Details.from(user);
+    }
+
     private void validationUserInfo(User user, UserCommand.Login command) {
         String encrypted = passwordEncoder.encodeWithSalt(command.password(), user.getSalt());
         if (!user.validatePassword(encrypted)) {

--- a/src/main/java/com/partimestudy/assignment/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/jwt/JwtProvider.java
@@ -50,7 +50,7 @@ public class JwtProvider implements TokenProvider {
             Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
-                .parseClaimsJwt(token);
+                .parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             throw new UnAuthorizedException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException e) {

--- a/src/main/java/com/partimestudy/assignment/infrastructure/user/UserReaderImpl.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/user/UserReaderImpl.java
@@ -27,4 +27,10 @@ public class UserReaderImpl implements UserReader {
         return userRepository.findByLoginId(loginId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
     }
+
+    @Override
+    public User findByUserToken(String userToken) {
+        return userRepository.findByUserToken(userToken)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
+    }
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/user/UserRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/user/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByLoginId(String loginId);
 
     Optional<User> findByLoginId(String loginId);
+
+    Optional<User> findByUserToken(String userToken);
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/filter/JwtFilter.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/filter/JwtFilter.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
-    private static final String BEARER = "bearer";
+    private static final String BEARER = "bearer ";
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final List<String> excludeUrlPatterns = List.of("/api/users/auth/**");

--- a/src/main/java/com/partimestudy/assignment/interfaces/user/UserApiController.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/user/UserApiController.java
@@ -2,6 +2,7 @@ package com.partimestudy.assignment.interfaces.user;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import com.partimestudy.assignment.domain.token.TokenInfo;
 import com.partimestudy.assignment.domain.user.UserCommand;
 import com.partimestudy.assignment.domain.user.UserInfo;
 import com.partimestudy.assignment.domain.user.docs.UserApiControllerDocs;
+import com.partimestudy.assignment.interfaces.support.Auth;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,13 @@ public class UserApiController implements UserApiControllerDocs {
         UserCommand.Login command = mapper.of(request);
         TokenInfo info = userFacade.login(command);
         UserDto.LoginResponse response = mapper.of(info);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/details")
+    public ResponseEntity<UserDto.UserDetailsResponse> userDetails(@Auth String userToken) {
+        UserInfo.Details info = userFacade.details(userToken);
+        UserDto.UserDetailsResponse response = mapper.of(info);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/user/UserDto.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/user/UserDto.java
@@ -62,4 +62,16 @@ public class UserDto {
     ) {
 
     }
+
+    @Schema(title = "내 정보 조회 응답 DTO")
+    public record UserDetailsResponse(
+        @Schema(defaultValue = "로그인 아이디", example = "bruuuni")
+        String loginId,
+        @Schema(defaultValue = "사용자명", example = "두번째호빵")
+        String name,
+        @Schema(defaultValue = "공부 목표", example = "공무원")
+        String purpose
+    ) {
+
+    }
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/user/UserDtoMapper.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/user/UserDtoMapper.java
@@ -21,4 +21,6 @@ public interface UserDtoMapper {
     UserCommand.Login of(UserDto.LoginRequest request);
 
     UserDto.LoginResponse of(TokenInfo info);
+
+    UserDto.UserDetailsResponse of(UserInfo.Details info);
 }

--- a/src/test/java/com/partimestudy/assignment/domain/user/UserServiceImplTest.java
+++ b/src/test/java/com/partimestudy/assignment/domain/user/UserServiceImplTest.java
@@ -96,4 +96,24 @@ class UserServiceImplTest {
         assertThatThrownBy(() -> userService.login(command))
             .isInstanceOf(BadRequestException.class);
     }
+
+    @DisplayName("내 정보 조회에 성공한다.")
+    @Test
+    void whenUserDetails_thenSuccess() {
+        // given
+        String userToken = "userToken";
+
+        User userMock = mock(User.class);
+
+        given(userMock.getLoginId()).willReturn("loginId");
+        given(userMock.getName()).willReturn("name");
+        given(userMock.getPurpose()).willReturn(User.Purpose.PUBLIC_OFFICIAL);
+        given(userReader.findByUserToken(userToken)).willReturn(userMock);
+
+        // when
+        userService.details(userToken);
+
+        // then
+        then(userReader).should(times(1)).findByUserToken(userToken);
+    }
 }


### PR DESCRIPTION
## Issue
- #11 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 내 정보 조회 기능을 구현 했습니다.
  - 잘못된 jwt 인증 토큰을 보낼 시, Exception이 발생하도록 했습니다.
- 내 정보 조회 기능을 테스트 했습니다. 

## 테스트 결과
### Request
```java
HTTP : GET
URL: /api/users/details
Authorization : BEARER
```

### Response : 성공시
`HTTP/1.1 200`
```
{
  "loginId": "bruuni",
  "name": "두번째호빵",
  "purpose": "공무원"
}
```

### Response : 실패시 [ 잘못된 토큰을 보낼 시 ]
`HTTP/1.1 401`

```
{
  "statusCode": 401,
  "message": "유효하지 않은 토큰입니다."
}
```

### 💥 TroubleShooting
내 정보 조회 시 jwt 토큰을 가지고 해당 User를 검증하게 되는데, User가 준 토큰을 검증할 때 아래와 같은 로직에서 에러가 발생했습니다.
```java
    @Override
    public void validateToken(String token) {
        try {
            Jwts.parserBuilder()
                .setSigningKey(secretKey)
                .build()
                .parseClaimsJwt(token);   // <- 에러가 발생한 지점
        } catch (ExpiredJwtException e) {
            throw new UnAuthorizedException(ErrorCode.EXPIRED_TOKEN);
        } catch (JwtException e) {
            throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
        }
    }
```
```
io.jsonwebtoken.UnsupportedJwtException: Signed Claims JWSs are not supported.
```
에러가 난 이유를 읽어보니 서명된 JWSs는 지원하지 않는다는 이유였습니다.
Jwt 토큰을 생성할 때 signWith을 통해서 서명을 진행했기 때문에 복호화 시에도 서명에 대한 검증을 진행해야 했지만, `parseClaimsJwt(...)` 메서드는 서명 검증 없이 단순히 헤더와 클레임만 추출하기 때문에 에러가 발생한 것이었습니다.
그래서 해당 `parseClaimsJwt(...)` 메서드를 서명 검증을 포함한 `parseClaimsJws(...)`로 변경하여 문제를 해결했습니다.
