### PR TITLE
[feat] 챌린지 주문(신청) 전체 내역 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.10'
@@ -30,6 +36,8 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.9'
 
+    annotationProcessor 'org.projectlombok:lombok'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -45,9 +53,14 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
     annotationProcessor(
-            'org.projectlombok:lombok',
             'org.projectlombok:lombok-mapstruct-binding:0.1.0'
     )
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -56,3 +69,25 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/** QueryDSL start **/
+
+// Querydsl 설정부
+def generated = "$buildDir/generated/querydsl"
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
+/** QueryDSL end **/

--- a/http-test/order-api.http
+++ b/http-test/order-api.http
@@ -4,10 +4,10 @@ Content-Type: application/json
 Authorization: {{access_token}}
 
 {
-  "challengeId": 3,
-  "challengeName": "금요일 1시간 공부하기",
+  "challengeId": 2,
+  "challengeName": "월요일 1시간 공부하기",
   "deposit": 10000,
-  "startedAt": "2024-09-30",
+  "startedAt": "2024-10-14",
   "studyTime": 1,
   "payMethod": "NAVER_PAY"
 }
@@ -16,3 +16,9 @@ Authorization: {{access_token}}
 GET http://localhost:8080/api/orders/4
 Content-Type: application/json
 Authorization: {{access_token}}
+
+### 챌린지 주문(신청) 내역 전체 조회
+GET http://localhost:8080/api/orders
+Content-Type: application/json
+Authorization: {{access_token}}
+

--- a/src/main/java/com/partimestudy/assignment/application/order/OrderFacade.java
+++ b/src/main/java/com/partimestudy/assignment/application/order/OrderFacade.java
@@ -1,5 +1,7 @@
 package com.partimestudy.assignment.application.order;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.partimestudy.assignment.domain.challenge.Challenge;
@@ -24,6 +26,10 @@ public class OrderFacade {
 
     public OrderInfo.Retrieve retrieve(OrderCommand.Retrieve command) {
         return orderService.retrieve(command);
+    }
+
+    public List<OrderInfo.RetrieveAll> retrieveAll(OrderCommand.RetrieveAll command) {
+        return orderService.retrieveAll(command);
     }
 
     private void challengeValidation(OrderCommand.Register command, Challenge challenge) {

--- a/src/main/java/com/partimestudy/assignment/domain/order/OrderCommand.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/OrderCommand.java
@@ -40,4 +40,12 @@ public class OrderCommand {
     ) {
 
     }
+
+    public record RetrieveAll(
+        String userToken,
+        int deposit,
+        String challengeName
+    ) {
+
+    }
 }

--- a/src/main/java/com/partimestudy/assignment/domain/order/OrderInfo.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/OrderInfo.java
@@ -31,4 +31,15 @@ public class OrderInfo {
             );
         }
     }
+
+    public record RetrieveAll(
+        String challengeName,
+        LocalDate startedAt,
+        Integer studyTime,
+        LocalDateTime createdAt,
+        int deposit,
+        int amount
+    ) {
+
+    }
 }

--- a/src/main/java/com/partimestudy/assignment/domain/order/OrderReader.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/OrderReader.java
@@ -1,6 +1,7 @@
 package com.partimestudy.assignment.domain.order;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface OrderReader {
     boolean existsByUserTokenAndChallengeIdAndStartedAt(
@@ -9,4 +10,6 @@ public interface OrderReader {
         LocalDate startedAt);
 
     Order findByOrderId(Integer orderId);
+
+    List<OrderInfo.RetrieveAll> findAllOrdersBySearchParams(OrderCommand.RetrieveAll command);
 }

--- a/src/main/java/com/partimestudy/assignment/domain/order/OrderService.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/OrderService.java
@@ -1,7 +1,11 @@
 package com.partimestudy.assignment.domain.order;
 
+import java.util.List;
+
 public interface OrderService {
     OrderInfo.Register register(String userToken, OrderCommand.Register command);
 
     OrderInfo.Retrieve retrieve(OrderCommand.Retrieve command);
+
+    List<OrderInfo.RetrieveAll> retrieveAll(OrderCommand.RetrieveAll command);
 }

--- a/src/main/java/com/partimestudy/assignment/domain/order/OrderServiceImpl.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.partimestudy.assignment.domain.order;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderServiceImpl implements OrderService {
     private final OrderReader orderReader;
     private final OrderStore orderStore;
@@ -42,5 +44,10 @@ public class OrderServiceImpl implements OrderService {
         Order order = orderReader.findByOrderId(command.orderId());
         order.validateUserToken(command.userToken());
         return OrderInfo.Retrieve.from(order);
+    }
+
+    @Override
+    public List<OrderInfo.RetrieveAll> retrieveAll(OrderCommand.RetrieveAll command) {
+        return orderReader.findAllOrdersBySearchParams(command);
     }
 }

--- a/src/main/java/com/partimestudy/assignment/domain/order/docs/OrderApiControllerDocs.java
+++ b/src/main/java/com/partimestudy/assignment/domain/order/docs/OrderApiControllerDocs.java
@@ -1,8 +1,11 @@
 package com.partimestudy.assignment.domain.order.docs;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.partimestudy.assignment.interfaces.order.OrderDto;
 import com.partimestudy.assignment.interfaces.support.Auth;
@@ -28,5 +31,13 @@ public interface OrderApiControllerDocs {
     ResponseEntity<OrderDto.RetrieveResponse> retrieve(
         @Auth String userToken,
         @PathVariable Integer orderId
+    );
+
+    @Operation(summary = "챌린지 주문(신청) 내역 전체 조회", description = "챌린지의 주문(신청) 내역을 전체 조회하기 위한 API")
+    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = OrderDto.RetrieveAllResponse.class)))
+    ResponseEntity<List<OrderDto.RetrieveAllResponse>> retrieveAll(
+        @Auth String userToken,
+        @RequestParam(required = false, defaultValue = "0") int deposit,
+        @RequestParam(required = false) String challengeName
     );
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.partimestudy.assignment.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderReaderImpl.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderReaderImpl.java
@@ -1,13 +1,17 @@
 package com.partimestudy.assignment.infrastructure.order;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 
 import com.partimestudy.assignment.domain.exception.ErrorCode;
 import com.partimestudy.assignment.domain.exception.NotFoundException;
 import com.partimestudy.assignment.domain.order.Order;
+import com.partimestudy.assignment.domain.order.OrderCommand;
+import com.partimestudy.assignment.domain.order.OrderInfo;
 import com.partimestudy.assignment.domain.order.OrderReader;
+import com.partimestudy.assignment.infrastructure.querydsl.OrderQueryDslRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderReaderImpl implements OrderReader {
     private final OrderRepository orderRepository;
+    private final OrderQueryDslRepository orderQueryDslRepository;
 
     @Override
     public boolean existsByUserTokenAndChallengeIdAndStartedAt(
@@ -29,5 +34,10 @@ public class OrderReaderImpl implements OrderReader {
     public Order findByOrderId(Integer orderId) {
         return orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ORDER));
+    }
+
+    @Override
+    public List<OrderInfo.RetrieveAll> findAllOrdersBySearchParams(OrderCommand.RetrieveAll command) {
+        return orderQueryDslRepository.findByUserTokenAndSearchParams(command);
     }
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
@@ -1,14 +1,39 @@
 package com.partimestudy.assignment.infrastructure.order;
 
+import static com.partimestudy.assignment.domain.order.QOrder.*;
+
 import java.time.LocalDate;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.partimestudy.assignment.domain.order.Order;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 public interface OrderRepository extends JpaRepository<Order, Integer> {
     boolean existsByUserTokenAndChallengeIdAndStartedAt(
         String userToken,
         Integer challengeId,
         LocalDate startedAt);
+
+    default BooleanExpression equalUserToken(String userToken) {
+        if (userToken == null) {
+            return null;
+        }
+        return order.userToken.eq(userToken);
+    }
+
+    default BooleanExpression lessThenDeposit(int deposit) {
+        if (deposit == 0) {
+            return null;
+        }
+        return order.deposit.lt(deposit);
+    }
+
+    default BooleanExpression equalChallengeName(String challengeName) {
+        if (challengeName == null) {
+            return null;
+        }
+        return order.challengeName.eq(challengeName);
+    }
+
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
@@ -33,7 +33,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
         if (challengeName == null) {
             return null;
         }
-        return order.challengeName.like(challengeName);
+        return order.challengeName.contains(challengeName);
     }
 
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/order/OrderRepository.java
@@ -29,11 +29,11 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
         return order.deposit.lt(deposit);
     }
 
-    default BooleanExpression equalChallengeName(String challengeName) {
+    default BooleanExpression containsChallengeName(String challengeName) {
         if (challengeName == null) {
             return null;
         }
-        return order.challengeName.eq(challengeName);
+        return order.challengeName.like(challengeName);
     }
 
 }

--- a/src/main/java/com/partimestudy/assignment/infrastructure/querydsl/OrderQueryDslRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/querydsl/OrderQueryDslRepository.java
@@ -31,7 +31,7 @@ public class OrderQueryDslRepository {
             .from(order)
             .where(
                 orderRepository.equalUserToken(command.userToken()),
-                orderRepository.equalChallengeName(command.challengeName()),
+                orderRepository.containsChallengeName(command.challengeName()),
                 orderRepository.lessThenDeposit(command.deposit())
             )
             .orderBy(order.createdAt.desc())

--- a/src/main/java/com/partimestudy/assignment/infrastructure/querydsl/OrderQueryDslRepository.java
+++ b/src/main/java/com/partimestudy/assignment/infrastructure/querydsl/OrderQueryDslRepository.java
@@ -1,0 +1,40 @@
+package com.partimestudy.assignment.infrastructure.querydsl;
+
+import static com.partimestudy.assignment.domain.order.QOrder.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.partimestudy.assignment.domain.order.OrderCommand;
+import com.partimestudy.assignment.domain.order.OrderInfo;
+import com.partimestudy.assignment.infrastructure.order.OrderRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+    private final OrderRepository orderRepository;
+
+    public List<OrderInfo.RetrieveAll> findByUserTokenAndSearchParams(OrderCommand.RetrieveAll command) {
+        return queryFactory.select(Projections.constructor(OrderInfo.RetrieveAll.class,
+                order.challengeName,
+                order.startedAt,
+                order.studyTime,
+                order.createdAt,
+                order.deposit,
+                order.deposit))
+            .from(order)
+            .where(
+                orderRepository.equalUserToken(command.userToken()),
+                orderRepository.equalChallengeName(command.challengeName()),
+                orderRepository.lessThenDeposit(command.deposit())
+            )
+            .orderBy(order.createdAt.desc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/partimestudy/assignment/interfaces/order/OrderApiController.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/order/OrderApiController.java
@@ -1,5 +1,7 @@
 package com.partimestudy.assignment.interfaces.order;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.partimestudy.assignment.application.order.OrderFacade;
@@ -44,6 +47,18 @@ public class OrderApiController implements OrderApiControllerDocs {
         OrderCommand.Retrieve command = mapper.of(orderId, userToken);
         OrderInfo.Retrieve info = orderFacade.retrieve(command);
         OrderDto.RetrieveResponse response = mapper.of(info);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OrderDto.RetrieveAllResponse>> retrieveAll(
+        @Auth String userToken,
+        @RequestParam(required = false, defaultValue = "0") int deposit,
+        @RequestParam(required = false) String challengeName
+    ) {
+        OrderCommand.RetrieveAll command = mapper.of(userToken, deposit, challengeName);
+        List<OrderInfo.RetrieveAll> info = orderFacade.retrieveAll(command);
+        List<OrderDto.RetrieveAllResponse> response = OrderDto.RetrieveAllResponse.from(info);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/order/OrderDto.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/order/OrderDto.java
@@ -2,8 +2,11 @@ package com.partimestudy.assignment.interfaces.order;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.partimestudy.assignment.domain.order.OrderInfo;
 import com.partimestudy.assignment.domain.order.payment.PayMethod;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -63,5 +66,35 @@ public class OrderDto {
         int amount
     ) {
 
+    }
+
+    @Schema(title = "챌린지 주문(신청) 전체 내역 조회 응답 DTO")
+    public record RetrieveAllResponse(
+        @Schema(defaultValue = "챌린지 이름", example = "월요일 1시간 공부하기")
+        String challengeName,
+        @Schema(defaultValue = "시작 일자", example = "2024-09-30")
+        LocalDate startedAt,
+        @Schema(defaultValue = "공부 시간", example = "1")
+        Integer studyTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @Schema(defaultValue = "생성 일자", example = "2024-09-28 17:43")
+        LocalDateTime createdAt,
+        @Schema(defaultValue = "보증금", example = "10000")
+        int deposit,
+        @Schema(defaultValue = "결제 금액", example = "10000")
+        int amount
+    ) {
+
+        public static List<OrderDto.RetrieveAllResponse> from(List<OrderInfo.RetrieveAll> info) {
+            return info.stream()
+                .map(retrieve -> new OrderDto.RetrieveAllResponse(
+                    retrieve.challengeName(),
+                    retrieve.startedAt(),
+                    retrieve.studyTime(),
+                    retrieve.createdAt(),
+                    retrieve.deposit(),
+                    retrieve.amount()
+                )).collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/com/partimestudy/assignment/interfaces/order/OrderDtoMapper.java
+++ b/src/main/java/com/partimestudy/assignment/interfaces/order/OrderDtoMapper.java
@@ -20,4 +20,6 @@ public interface OrderDtoMapper {
     OrderCommand.Retrieve of(Integer orderId, String userToken);
 
     OrderDto.RetrieveResponse of(OrderInfo.Retrieve info);
+
+    OrderCommand.RetrieveAll of(String userToken, int deposit, String challengeName);
 }

--- a/src/test/java/com/partimestudy/assignment/domain/order/OrderServiceImplTest.java
+++ b/src/test/java/com/partimestudy/assignment/domain/order/OrderServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,5 +85,29 @@ class OrderServiceImplTest {
 
         // then
         then(orderReader).should(times(1)).findByOrderId(command.orderId());
+    }
+
+    @DisplayName("챌린지 주문(신청) 내역 전체 조회에 성공한다.")
+    @Test
+    void whenRetrieveOrders_thenSuccess() {
+        // given
+        OrderCommand.RetrieveAll command = new OrderCommand.RetrieveAll(
+            "userToken",
+            12000,
+            "원하는 일정으로 공부하기");
+        OrderInfo.RetrieveAll info = mock(OrderInfo.RetrieveAll.class);
+        List<OrderInfo.RetrieveAll> allInfo = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            allInfo.add(info);
+        }
+
+        given(orderReader.findAllOrdersBySearchParams(command)).willReturn(allInfo);
+
+        // when
+        orderService.retrieveAll(command);
+
+        // then
+        then(orderReader).should(times(1)).findAllOrdersBySearchParams(command);
     }
 }


### PR DESCRIPTION
## Issue
- #19 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 챌린지 주문(신청) 내역을 전체 조회하는 기능을 구현했습니다.
  - querydsl을 이용하여 조건에 맞추어 검색이 가능하도록 구현했습니다.
- 챌린지 주문(신청) 내역을 전체 조회 기능을 테스트했습니다.

## 테스트 결과
### Request
```java
HTTP : GET
URL: /api/orders
Authorization : BEARER
```

### Response : 성공시
`HTTP/1.1 200`
```
[
  {
    "challengeName": "월요일 1시간 공부하기",
    "startedAt": "2024-10-14",
    "studyTime": 1,
    "createdAt": "2024-09-30 16:48",
    "deposit": 10000,
    "amount": 10000
  },
  {
    "challengeName": "월요일 1시간 공부하기",
    "startedAt": "2024-10-07",
    "studyTime": 1,
    "createdAt": "2024-09-30 16:47",
    "deposit": 10000,
    "amount": 10000
  },
  {
    "challengeName": "금요일 1시간 공부하기",
    "startedAt": "2024-09-27",
    "studyTime": 1,
    "createdAt": "2024-09-27 22:16",
    "deposit": 10000,
    "amount": 10000
  }
]
```
### Request [ 쿼리 파라미터로 조건을 전달할 시 ]
```java
HTTP : GET
URL: /api/orders?challengeName=월요일
Authorization : BEARER
```

### Response : 성공시
`HTTP/1.1 200`
```
[
  {
    "challengeName": "월요일 1시간 공부하기",
    "startedAt": "2024-10-14",
    "studyTime": 1,
    "createdAt": "2024-09-30 16:48",
    "deposit": 10000,
    "amount": 10000
  },
  {
    "challengeName": "월요일 1시간 공부하기",
    "startedAt": "2024-10-07",
    "studyTime": 1,
    "createdAt": "2024-09-30 16:47",
    "deposit": 10000,
    "amount": 10000
  }
]
```
